### PR TITLE
Fixed Manhattan distance in vectors

### DIFF
--- a/src/main/java/me/jordin/deltoid/vector/Vec2.java
+++ b/src/main/java/me/jordin/deltoid/vector/Vec2.java
@@ -95,7 +95,7 @@ public class Vec2 implements Vector<Vec2> {
      */
     @Override
     public double manhattan() {
-        return this.x + this.y;
+        return Math.abs(this.x) + Math.abs(this.y);
     }
 
     /**

--- a/src/main/java/me/jordin/deltoid/vector/Vec3.java
+++ b/src/main/java/me/jordin/deltoid/vector/Vec3.java
@@ -126,7 +126,7 @@ public class Vec3 implements Vector<Vec3> {
      */
     @Override
     public double manhattan() {
-        return x + y + z;
+        return Math.abs(x) + Math.abs(y) + Math.abs(z);
     }
 
     /**


### PR DESCRIPTION
The manhattan distance in the Vec2 and Vec3 were incorrect in negative space.

```java
return x + y + z;
```
should be
```csharp
return Math.abs(x)+Math.abs(y)+Math.abs(z);
```